### PR TITLE
argcomplete 3.5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,57 @@
-{% set version = "1.12.3" %}
+{% set name = "argcomplete" %}
+{% set version = "3.5.3" %}
 
 package:
-  name: argcomplete
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: argcomplete-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/a/argcomplete/argcomplete-{{ version }}.tar.gz
-  md5: ded03f9c5d41c193dfe5869634d78211
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c12bf50eded8aebb298c7b7da7a5ff3ee24dffd9f5281867dfe1424b58c55392
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - activate-global-python-argcomplete = argcomplete.scripts.activate_global_python_argcomplete:main
+    - python-argcomplete-check-easy-install-script = argcomplete.scripts.python_argcomplete_check_easy_install_script:main
+    - register-python-argcomplete = argcomplete.scripts.register_python_argcomplete:main
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python >=3.5
-    - setuptools
+    - python
     - pip
+    - hatchling
+    - hatch-vcs
   run:
-    - python >=3.5
-    - importlib_metadata >=0.23,<5
+    - python
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
   imports:
     - argcomplete
+    - argcomplete.completers
+    - argcomplete.io
+    - argcomplete.lexers
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - activate-global-python-argcomplete --help
+    - register-python-argcomplete --help
+    # FileNotFoundError: [Errno 2] No such file or directory: '--help'
+    # - python-argcomplete-check-easy-install-script  --help
+    # Skip upstream tests due to numerous platform-specific issues they cannot be run with pytest so difficult to exclude by test or file.
+  requires:
+    - pip
 
 about:
   home: https://github.com/kislyuk/argcomplete
   license: Apache-2.0
-  summary: Bash tab completion for argparse
   license_family: Apache
   license_file: LICENSE.rst
-  doc_url: https://argcomplete.readthedocs.io
+  summary: Argcomplete provides easy, extensible command line tab completion of arguments for your Python application.
+  description: Argcomplete provides easy, extensible command line tab completion of arguments for your Python application.
+  doc_url: https://kislyuk.github.io/argcomplete
   dev_url: https://github.com/kislyuk/argcomplete
 
 extra:


### PR DESCRIPTION
argcomplete 3.5.3

**Destination channel:** defaults

### Links

- [PKG-13827](https://anaconda.atlassian.net/browse/PKG-13827) 
- [Upstream repository](https://github.com/kislyuk/argcomplete/tree/v3.5.3)

### Explanation of changes:

-  build previous version


[PKG-13827]: https://anaconda.atlassian.net/browse/PKG-13827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ